### PR TITLE
dockerize_fix_build_for_linux

### DIFF
--- a/Formula/dockerize.rb
+++ b/Formula/dockerize.rb
@@ -15,12 +15,13 @@ class Dockerize < Formula
   depends_on "go" => :build
 
   def install
+    platform = OS.mac? ? "darwin" : "linux"
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/jwilder/dockerize").install buildpath.children
     ENV.append_path "PATH", buildpath/"bin"
     cd "src/github.com/jwilder/dockerize" do
       system "make", "dist"
-      bin.install "dist/darwin/amd64/dockerize"
+      bin.install "dist/#{platform}/amd64/dockerize"
     end
   end
 


### PR DESCRIPTION
Dockerize produces Mach-O executable so this fix is using `OS.mac? ? "darwin" : "linux"` condition to build right binary upon the user's platform.

- [v] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/master/CONTRIBUTING.md)?
- [v] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [v] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [v] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [v] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
